### PR TITLE
Default site redirection now works on not just the / root path but th…

### DIFF
--- a/spvitamin-spring-admin/src/main/java/hu/perit/spvitamin/spring/mvc/AdminGuiRedirectConfig.java
+++ b/spvitamin-spring-admin/src/main/java/hu/perit/spvitamin/spring/mvc/AdminGuiRedirectConfig.java
@@ -1,6 +1,7 @@
 package hu.perit.spvitamin.spring.mvc;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -8,28 +9,37 @@ import hu.perit.spvitamin.spring.config.AdminProperties;
 import hu.perit.spvitamin.spring.config.SysConfig;
 
 @Configuration
-public class AdminGuiRedirectConfig implements WebMvcConfigurer
-{
+public class AdminGuiRedirectConfig implements WebMvcConfigurer {
     @Override
-    public void addViewControllers(ViewControllerRegistry registry)
-    {
+    public void addViewControllers(ViewControllerRegistry registry) {
         // adminProperties.getAdminGuiUrl() must be e.g.: /admin-gui
         AdminProperties adminProperties = SysConfig.getAdminProperties();
 
-        if (!adminProperties.getDefaultSiteUrl().isBlank())
-        {
-            String target = String.format("redirect:%s/%s", adminProperties.getDefaultSiteUrl(),
-                adminProperties.getDefaultSiteRootFileName());
+        if (!adminProperties.getDefaultSiteUrl().isBlank()) {
+            String target = String.format("redirect:%s/%s", adminProperties.getDefaultSiteUrl(), adminProperties.getDefaultSiteRootFileName());
 
             registry.addViewController("/").setViewName(target);
+
+            registry.addViewController(adminProperties.getDefaultSiteUrl()).setViewName(target);
+            registry.addViewController(adminProperties.getDefaultSiteUrl() + "/").setViewName(target);
         }
 
-        if (!adminProperties.getAdminGuiUrl().isBlank())
-        {
+        if (!adminProperties.getAdminGuiUrl().isBlank()) {
             String target = String.format("redirect:%s/%s", adminProperties.getAdminGuiUrl(), adminProperties.getAdminGuiRootFileName());
 
             registry.addViewController(adminProperties.getAdminGuiUrl()).setViewName(target);
             registry.addViewController(adminProperties.getAdminGuiUrl() + "/").setViewName(target);
         }
     }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        AdminProperties adminProperties = SysConfig.getAdminProperties();
+        if (adminProperties.getDefaultSiteStaticContentsPath() != null) {
+            registry
+                    .addResourceHandler(adminProperties.getDefaultSiteUrl() + "/**")
+                    .addResourceLocations(adminProperties.getDefaultSiteStaticContentsPath());
+        }
+    }
+
 }

--- a/spvitamin-spring-general/src/main/java/hu/perit/spvitamin/spring/config/AdminProperties.java
+++ b/spvitamin-spring-general/src/main/java/hu/perit/spvitamin/spring/config/AdminProperties.java
@@ -40,6 +40,7 @@ public class AdminProperties {
 
 	private String defaultSiteUrl = "";
 	private String defaultSiteRootFileName = "index.html";
+	private String defaultSiteStaticContentsPath;
 
 	// e.g. admin.admin-gui-url=/alma
 	private String adminGuiUrl = "";


### PR DESCRIPTION
…e /<admin.default-site-url> and /<admin.default-site-url>/ (property set in propeties). This default site now can be served from external file if the property "admin.default-site-static-contents-path" (example value on Windows: file:///<drive>:/<path-to-static-content-files>/; on Linux: file:/<path-to-static-content-files>/). If the property is unset, the default site is served the usual way.